### PR TITLE
feat(stream-poller): Create service with Twitch access token fetching and renewal (#2)

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,7 +1,7 @@
 # Twitch Watcher - Project Plan
 
 ## Overview
-Twitch Watcher is a microservice-based, event-driven application that listens for Twitch EventSub events (e.g., new streams for specified games or streamers) and sends notifications to designated Discord servers via webhooks. It features a Discord-authenticated web frontend where users can configure which streams should trigger notifications.
+Twitch Watcher is a microservice-based, event-driven application that listens for Twitch events (e.g., new streams for specified games or streamers) and sends notifications to designated Discord servers via webhooks. It features a Discord-authenticated web frontend where users can configure which streams should trigger notifications.
 
 ---
 
@@ -45,10 +45,10 @@ twitch-watcher/
 │   └── secrets/
 │
 ├── services/                # Backend microservices
-│   ├── twitch-listener/
-│   ├── webhook-manager/
+│   ├── stream-poller/
 │   ├── auth-service/
-│   └── notification-sender/
+│   ├── user-service/
+│   └── notification-dispatcher/
 │
 ├── frontend/                # React frontend app (Vite or Next.js)
 │
@@ -68,17 +68,120 @@ twitch-watcher/
 
 ---
 
+## Domain Overview
+
+### 1. Stream Discovery
+
+**Purpose**: Detect and monitor Twitch streams through polling integration.
+
+**Responsibilities**:
+- Poll Twitch API (`/helix/streams`) for stream activity.
+- Manage rate limits and pagination.
+- Emit `StreamStarted` events to RabbitMQ.
+
+**Microservices**:
+- `stream-poller`
+
+---
+
+### 2. Notification
+
+**Purpose**: Deliver stream-related alerts to users through Discord webhooks.
+
+**Responsibilities**:
+- Subscribe to `StreamStarted` events.
+- Query user preferences to find target Discord webhooks.
+- Format and send messages via Discord.
+- Handle retries or failures gracefully.
+
+**Microservices**:
+- `notification-dispatcher`
+
+---
+
+### 3. User Preferences
+
+**Purpose**: Allow users to manage which games or streamers they want to be notified about.
+
+**Responsibilities**:
+- Store tracked streamers and games per user.
+- Store Discord webhook configurations.
+- Provide a CRUD API for managing preferences.
+- Validate incoming data (e.g., valid Twitch IDs, Discord webhooks).
+
+**Microservices**:
+- `user-preferences`
+
+---
+
+### 4. Authentication
+
+**Purpose**: Authenticate and authorize users accessing the system.
+
+**Responsibilities**:
+- Authenticate users via Discord OAuth or a third-party service (e.g., Clerk).
+- Manage tokens or session validation.
+- Secure access to user-specific data and preferences.
+
+**Microservices**:
+- `auth-service` or integration with Clerk/Auth0/Firebase Auth
+
+---
+
+### 5. Web Dashboard (Optional BFF)
+
+**Purpose**: Frontend UI for users to manage their configuration.
+
+**Responsibilities**:
+- Display tracking status and logs.
+- Allow users to manage watchlist and Discord webhooks.
+- Authenticate users and secure access.
+- Use GraphQL or REST to proxy backend services.
+
+**Microservices**:
+- `graphql-api` (BFF)
+- `frontend-app` (React, Vite, etc.)
+
+---
+
+### 6. Event Bus (Infrastructure Domain)
+
+**Purpose**: Enable asynchronous communication between services.
+
+**Responsibilities**:
+- Route events like `StreamStarted`, `StreamEnded`, `DeliveryFailed`.
+- Allow microservices to publish/subscribe without tight coupling.
+- Ensure reliability and delivery guarantees.
+
+**Technology**:
+- RabbitMQ
+
+---
+
+### Domain-to-Service Mapping Summary
+
+| Domain             | Purpose                       | Microservice(s)                      |
+|--------------------|-------------------------------|--------------------------------------|
+| Stream Discovery   | Detect live streams           | `stream-poller`                      |
+| Notification       | Deliver alerts                | `notification-dispatcher`            |
+| User Preferences   | Manage user watchlists        | `user-service`                       |
+| Authentication     | User auth and access control  | `auth-service` or 3rd-party auth     |
+| Web Dashboard      | UI and frontend gateway       | `graphql-api`, `frontend-app`        |
+| Event Bus          | Event communication layer     | RabbitMQ (infrastructure component)  |
+
+---
+
 ## Core Microservices
 
 1. **Twitch Listener**
-   - Handles Twitch EventSub webhook callbacks
+   - Polls Twitch API for new stream events
    - Validates & forwards events into RabbitMQ
 
 2. **Notification Dispatcher**
    - Listens to RabbitMQ
    - Sends Discord webhook messages
    
-3. **Webhook Manager**
+3. **User Service**
    - Stores user configuration (e.g., target game/streamer, Discord webhook)
    - Manages webhook creation/deletion
 
@@ -100,7 +203,6 @@ twitch-watcher/
 - [ ] View/manage existing webhooks
 - [ ] Subscribe to Twitch streams by streamer or game
 - [ ] Discord webhook notification setup
-- [ ] Persistent Twitch EventSub subscriptions
 - [ ] Real-time event propagation via RabbitMQ
 
 ---

--- a/services/stream-poller/.env.example
+++ b/services/stream-poller/.env.example
@@ -1,0 +1,6 @@
+TWITCH_CLIENT_ID=example-twitch-id
+TWITCH_CLIENT_SECRET=example-twitch-secret
+POLL_INTERVAL_SECONDS=60
+RABBITMQ_URL=amqp://user:pass@host:10000/vhost
+REDIS_URL=redis://user:pass@host:6380
+LOG_LEVEL=info

--- a/services/stream-poller/.gitignore
+++ b/services/stream-poller/.gitignore
@@ -1,0 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env

--- a/services/stream-poller/PROJECT_PLAN.md
+++ b/services/stream-poller/PROJECT_PLAN.md
@@ -70,9 +70,6 @@ The `stream-poller` microservice is responsible for detecting when Twitch stream
 ## Folder Structure
 ```
 stream-poller/
-├── cmd/
-│   └── stream-poller/          # Main application entrypoint
-│       └── main.go
 ├── internal/
 │   ├── poller/                 # Game and user poll logic
 │   │   ├── game.go
@@ -87,6 +84,7 @@ stream-poller/
 │   └── config/                 # Config loading and validation
 │       └── env.go
 ├── Dockerfile
+├── main.go                     # Main application entrypoint
 ├── go.mod
 ├── go.sum
 └── README.md

--- a/services/stream-poller/PROJECT_PLAN.md
+++ b/services/stream-poller/PROJECT_PLAN.md
@@ -1,7 +1,7 @@
-# Twitch Watcher - Twitch Listener Microservice Plan
+# Twitch Watcher - Stream Poller Microservice Plan
 
 ## Overview
-The `twitch-listener` microservice is responsible for detecting when Twitch streams go live for specific games or streamers. It polls the Twitch API at regular intervals, detects new stream activity, and publishes structured event messages to RabbitMQ. Active streams are tracked via DragonflyDB for change detection.
+The `stream-poller` microservice is responsible for detecting when Twitch streams go live for specific games or streamers. It polls the Twitch API at regular intervals, detects new stream activity, and publishes structured event messages to RabbitMQ. Active streams are tracked via DragonflyDB for change detection.
 
 ---
 
@@ -69,9 +69,9 @@ The `twitch-listener` microservice is responsible for detecting when Twitch stre
 
 ## Folder Structure
 ```
-twitch-listener/
+stream-poller/
 ├── cmd/
-│   └── twitch-listener/        # Main application entrypoint
+│   └── stream-poller/          # Main application entrypoint
 │       └── main.go
 ├── internal/
 │   ├── poller/                 # Game and user poll logic

--- a/services/stream-poller/go.mod
+++ b/services/stream-poller/go.mod
@@ -1,0 +1,14 @@
+module github.com/khiemnguyen15/twitch-watcher/services/stream-poller
+
+go 1.24.1
+
+require (
+	github.com/joho/godotenv v1.5.1
+	github.com/rs/zerolog v1.34.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	golang.org/x/sys v0.12.0 // indirect
+)

--- a/services/stream-poller/go.mod
+++ b/services/stream-poller/go.mod
@@ -5,10 +5,14 @@ go 1.24.1
 require (
 	github.com/joho/godotenv v1.5.1
 	github.com/rs/zerolog v1.34.0
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/stream-poller/go.sum
+++ b/services/stream-poller/go.sum
@@ -1,0 +1,17 @@
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
+github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/services/stream-poller/go.sum
+++ b/services/stream-poller/go.sum
@@ -1,4 +1,6 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
@@ -8,10 +10,18 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/stream-poller/internal/config/env.go
+++ b/services/stream-poller/internal/config/env.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	_ "github.com/joho/godotenv/autoload"
+)
+
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	PollInterval time.Duration
+	RabbitMQURL  string
+	RedisURL     string
+	LogLevel     string
+}
+
+func Load() Config {
+	return Config{
+		ClientID:     mustGet("TWITCH_CLIENT_ID"),
+		ClientSecret: mustGet("TWITCH_CLIENT_SECRET"),
+		PollInterval: mustGetDuration("POLL_INTERVAL_SECONDS"),
+		RabbitMQURL:  mustGet("RABBITMQ_URL"),
+		RedisURL:     mustGet("REDIS_URL"),
+		LogLevel:     getDefault("LOG_LEVEL", "info"),
+	}
+}
+
+func mustGet(key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		log.Fatalf("missing required environment variable: %s", key)
+	}
+	return val
+}
+
+func mustGetDuration(key string) time.Duration {
+	seconds := mustGet(key)
+	sec, err := strconv.Atoi(seconds)
+	if err != nil {
+		log.Fatalf("invalid duration value for %s: %v", key, err)
+	}
+	return time.Duration(sec) * time.Second
+}
+
+func getDefault(key string, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/services/stream-poller/internal/twitch/auth.go
+++ b/services/stream-poller/internal/twitch/auth.go
@@ -1,0 +1,88 @@
+package twitch
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type TokenManager struct {
+	clientID     string
+	clientSecret string
+	accessToken  string
+	expiry       time.Time
+	mu           sync.Mutex
+}
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func NewTokenManager(clientID, clientSecret string) *TokenManager {
+	return &TokenManager{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}
+}
+
+func (tm *TokenManager) GetAccessToken() (string, error) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if time.Now().Before(tm.expiry) && tm.accessToken != "" {
+		return tm.accessToken, nil
+	}
+
+	token, expiry, err := tm.fetchNewToken()
+	if err != nil {
+		return "", err
+	}
+
+	tm.accessToken = token
+	tm.expiry = time.Now().Add(expiry)
+
+	return tm.accessToken, nil
+}
+
+func (tm *TokenManager) fetchNewToken() (string, time.Duration, error) {
+	url := "https://id.twitch.tv/oauth2/token"
+
+	data := fmt.Sprintf(
+		"client_id=%s&client_secret=%s&grant_type=client_credentials",
+		tm.clientID,
+		tm.clientSecret,
+	)
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(data))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", 0, fmt.Errorf("failed to fetch token: status %d", resp.StatusCode)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return "", 0, err
+	}
+
+	if tr.AccessToken == "" {
+		return "", 0, errors.New("received empty access token")
+	}
+
+	return tr.AccessToken, time.Duration(tr.ExpiresIn) * time.Second, nil
+}

--- a/services/stream-poller/internal/twitch/auth.go
+++ b/services/stream-poller/internal/twitch/auth.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -36,15 +37,16 @@ func (tm *TokenManager) GetAccessToken() (string, error) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
+	// Use cached token
 	if time.Now().Before(tm.expiry) && tm.accessToken != "" {
 		return tm.accessToken, nil
 	}
 
+	// Fetch new token
 	token, expiry, err := tm.fetchNewToken()
 	if err != nil {
 		return "", err
 	}
-
 	tm.accessToken = token
 	tm.expiry = time.Now().Add(expiry)
 
@@ -64,7 +66,7 @@ func (tm *TokenManager) fetchNewToken() (string, time.Duration, error) {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", 0, err
@@ -72,12 +74,14 @@ func (tm *TokenManager) fetchNewToken() (string, time.Duration, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", 0, fmt.Errorf("failed to fetch token: status %d", resp.StatusCode)
+		// Attempt to read body for detailed error messages from Twitch
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", 0, fmt.Errorf("failed to fetch token: status %d, body: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var tr tokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
-		return "", 0, err
+		return "", 0, fmt.Errorf("failed to decode token response: %w", err)
 	}
 
 	if tr.AccessToken == "" {

--- a/services/stream-poller/internal/twitch/auth.go
+++ b/services/stream-poller/internal/twitch/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -56,8 +57,8 @@ func (tm *TokenManager) GetAccessToken() (string, error) {
 func (tm *TokenManager) fetchNewToken() (string, time.Duration, error) {
 	data := fmt.Sprintf(
 		"client_id=%s&client_secret=%s&grant_type=client_credentials",
-		tm.clientID,
-		tm.clientSecret,
+		url.QueryEscape(tm.clientID),
+		url.QueryEscape(tm.clientSecret),
 	)
 
 	req, err := http.NewRequest(http.MethodPost, fetchURL, strings.NewReader(data))

--- a/services/stream-poller/internal/twitch/auth.go
+++ b/services/stream-poller/internal/twitch/auth.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+var fetchURL = "https://id.twitch.tv/oauth2/token"
+
 type TokenManager struct {
 	clientID     string
 	clientSecret string
@@ -50,15 +52,13 @@ func (tm *TokenManager) GetAccessToken() (string, error) {
 }
 
 func (tm *TokenManager) fetchNewToken() (string, time.Duration, error) {
-	url := "https://id.twitch.tv/oauth2/token"
-
 	data := fmt.Sprintf(
 		"client_id=%s&client_secret=%s&grant_type=client_credentials",
 		tm.clientID,
 		tm.clientSecret,
 	)
 
-	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(data))
+	req, err := http.NewRequest(http.MethodPost, fetchURL, strings.NewReader(data))
 	if err != nil {
 		return "", 0, err
 	}

--- a/services/stream-poller/internal/twitch/auth_test.go
+++ b/services/stream-poller/internal/twitch/auth_test.go
@@ -1,0 +1,204 @@
+package twitch
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testClientID     = "test_client_id"
+	testClientSecret = "test_client_secret"
+	testAccessToken  = "test_access_token"
+	testExpiresIn    = 3600 // seconds
+)
+
+func mockTokenServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	// Override the fetchNewToken URL temporarily for testing
+	originalURL := fetchURL
+	fetchURL = server.URL
+	t.Cleanup(func() {
+		server.Close()
+		fetchURL = originalURL // Restore original URL after test completion.
+	})
+	return server
+}
+
+func TestNewTokenManager(t *testing.T) {
+	tm := NewTokenManager(testClientID, testClientSecret)
+	require.NotNil(t, tm)
+	assert.Equal(t, testClientID, tm.clientID)
+	assert.Equal(t, testClientSecret, tm.clientSecret)
+	assert.Empty(t, tm.accessToken)
+	assert.True(t, tm.expiry.IsZero())
+}
+
+func TestGetAccessToken_Success_FirstFetch(t *testing.T) {
+	_ = mockTokenServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		err := r.ParseForm()
+		require.NoError(t, err)
+		assert.Equal(t, testClientID, r.FormValue("client_id"))
+		assert.Equal(t, testClientSecret, r.FormValue("client_secret"))
+		assert.Equal(t, "client_credentials", r.FormValue("grant_type"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: testAccessToken,
+			ExpiresIn:   testExpiresIn,
+		})
+	})
+
+	tm := NewTokenManager(testClientID, testClientSecret)
+	token, err := tm.GetAccessToken()
+
+	require.NoError(t, err)
+	assert.Equal(t, testAccessToken, token)
+	assert.Equal(t, testAccessToken, tm.accessToken)                                                             // Check internal state
+	assert.WithinDuration(t, time.Now().Add(time.Duration(testExpiresIn)*time.Second), tm.expiry, 5*time.Second) // Allow some leeway
+}
+
+func TestGetAccessToken_Success_CachedToken(t *testing.T) {
+	tm := NewTokenManager(testClientID, testClientSecret)
+	// Pre-populate the token manager with a valid token
+	tm.accessToken = testAccessToken
+	tm.expiry = time.Now().Add(1 * time.Hour)
+
+	token, err := tm.GetAccessToken()
+
+	require.NoError(t, err)
+	assert.Equal(t, testAccessToken, token)
+}
+
+func TestGetAccessToken_Success_ExpiredTokenRefetch(t *testing.T) {
+	fetchCount := 0
+	newToken := "new_test_access_token"
+	newExpiry := 1800
+
+	_ = mockTokenServer(t, func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: newToken,
+			ExpiresIn:   newExpiry,
+		})
+	})
+
+	tm := NewTokenManager(testClientID, testClientSecret)
+	// Set an expired token
+	tm.accessToken = "expired_token"
+	tm.expiry = time.Now().Add(-1 * time.Minute)
+
+	token, err := tm.GetAccessToken()
+
+	require.NoError(t, err)
+	assert.Equal(t, newToken, token)
+	assert.Equal(t, 1, fetchCount, "Expected fetchNewToken to be called once")
+	assert.Equal(t, newToken, tm.accessToken)
+	assert.WithinDuration(t, time.Now().Add(time.Duration(newExpiry)*time.Second), tm.expiry, 5*time.Second)
+}
+
+func TestGetAccessToken_Error_FetchFailed_StatusNotOK(t *testing.T) {
+	_ = mockTokenServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, "Internal Server Error")
+	})
+
+	tm := NewTokenManager(testClientID, testClientSecret)
+	token, err := tm.GetAccessToken()
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.Contains(t, err.Error(), "failed to fetch token: status 500")
+	assert.Empty(t, tm.accessToken) // Ensure internal state wasn't updated
+	assert.True(t, tm.expiry.IsZero())
+}
+
+func TestGetAccessToken_Error_FetchFailed_EmptyToken(t *testing.T) {
+	_ = mockTokenServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "",
+			ExpiresIn:   testExpiresIn,
+		})
+	})
+
+	tm := NewTokenManager(testClientID, testClientSecret)
+	token, err := tm.GetAccessToken()
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.EqualError(t, err, "received empty access token")
+	assert.Empty(t, tm.accessToken)
+	assert.True(t, tm.expiry.IsZero())
+}
+
+func TestGetAccessToken_Error_FetchFailed_InvalidJson(t *testing.T) {
+	_ = mockTokenServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"access_token": "token", "expires_in": "not_an_int"}`) // Invalid expires_in type
+	})
+
+	tm := NewTokenManager(testClientID, testClientSecret)
+	token, err := tm.GetAccessToken()
+
+	require.Error(t, err)
+	assert.Empty(t, token)
+	assert.Contains(t, err.Error(), "failed to decode token response") // Check for decode error
+	assert.Empty(t, tm.accessToken)
+	assert.True(t, tm.expiry.IsZero())
+}
+
+func TestGetAccessToken_ConcurrentAccess(t *testing.T) {
+	fetchCount := 0
+	_ = mockTokenServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Simulate network delay to increase chance of race condition without mutex
+		time.Sleep(10 * time.Millisecond)
+		fetchCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: testAccessToken,
+			ExpiresIn:   testExpiresIn,
+		})
+	})
+
+	tm := NewTokenManager(testClientID, testClientSecret)
+	numGoroutines := 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Use a channel to signal all goroutines to start roughly simultaneously.
+	startSignal := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-startSignal                     // Wait for the signal before proceeding.
+			token, err := tm.GetAccessToken() // All goroutines call this concurrently.
+			assert.NoError(t, err)
+			assert.Equal(t, testAccessToken, token)
+		}()
+	}
+
+	close(startSignal) // Signal all goroutines to start
+	wg.Wait()
+
+	// Verify that the mutex prevented multiple token fetches despite concurrent calls.
+	assert.Equal(t, 1, fetchCount, "fetchNewToken should only be called once during concurrent access")
+	assert.Equal(t, testAccessToken, tm.accessToken)
+	assert.WithinDuration(t, time.Now().Add(time.Duration(testExpiresIn)*time.Second), tm.expiry, 5*time.Second)
+}

--- a/services/stream-poller/main.go
+++ b/services/stream-poller/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	level, err := zerolog.ParseLevel(cfg.LogLevel)
 	if err != nil {
+		// Default to InfoLevel
 		level = zerolog.InfoLevel
 	}
 	zerolog.SetGlobalLevel(level)
@@ -41,6 +42,9 @@ func main() {
 	log.Info().Msg("Fetched Twitch access token")
 
 	// DEBUG: Test the access token
+	// This section makes a simple API call to verify the obtained access token is valid.
+	// TODO: Replace this debug block with the actual stream polling logic.
+	// ================= BEGIN DEBUG BLOCK =================
 	req, err := http.NewRequest(http.MethodGet, "https://api.twitch.tv/helix/streams", nil)
 	if err != nil {
 		log.Fatal().
@@ -65,4 +69,5 @@ func main() {
 			Msg("Unexpected status code")
 	}
 	log.Info().Msg("Successfully fetched Twitch streams")
+	// ================== END DEBUG BLOCK ==================
 }

--- a/services/stream-poller/main.go
+++ b/services/stream-poller/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/khiemnguyen15/twitch-watcher/services/stream-poller/internal/config"
+	"github.com/khiemnguyen15/twitch-watcher/services/stream-poller/internal/twitch"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func main() {
+	cfg := config.Load()
+
+	level, err := zerolog.ParseLevel(cfg.LogLevel)
+	if err != nil {
+		level = zerolog.InfoLevel
+	}
+	zerolog.SetGlobalLevel(level)
+
+	// Enable pretty logging in development
+	if zerolog.GlobalLevel() == zerolog.DebugLevel {
+		log.Logger = log.Output(zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			TimeFormat: time.RFC3339,
+		})
+	}
+
+	log.Info().Msg("Loaded app config")
+
+	tokenManager := twitch.NewTokenManager(cfg.ClientID, cfg.ClientSecret)
+
+	token, err := tokenManager.GetAccessToken()
+	if err != nil {
+		log.Fatal().
+			Err(err).
+			Msg("Error getting Twitch access token")
+	}
+	log.Info().Msg("Fetched Twitch access token")
+
+	// DEBUG: Test the access token
+	req, err := http.NewRequest(http.MethodGet, "https://api.twitch.tv/helix/streams", nil)
+	if err != nil {
+		log.Fatal().
+			Err(err).
+			Msg("Error creating streams request")
+	}
+	req.Header.Set("Client-Id", cfg.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal().
+			Err(err).
+			Msg("Error getting Twitch streams")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Fatal().
+			Str("status", resp.Status).
+			Msg("Unexpected status code")
+	}
+	log.Info().Msg("Successfully fetched Twitch streams")
+}

--- a/services/twitch-listener/PROJECT_PLAN.md
+++ b/services/twitch-listener/PROJECT_PLAN.md
@@ -1,0 +1,113 @@
+# Twitch Watcher - Twitch Listener Microservice Plan
+
+## Overview
+The `twitch-listener` microservice is responsible for detecting when Twitch streams go live for specific games or streamers. It polls the Twitch API at regular intervals, detects new stream activity, and publishes structured event messages to RabbitMQ. Active streams are tracked via DragonflyDB for change detection.
+
+---
+
+## Responsibilities
+- Poll Twitch API for active streams by `game_id` and `user_id`
+- Batch poll requests in groups of up to 100 IDs to reduce request volume
+- Handle Twitch API pagination
+- Manage concurrency using goroutines with rate-limited throttling
+- Track currently active streams using DragonflyDB
+- Detect new stream starts and publish events to RabbitMQ
+- Authenticate to Twitch using an App Access Token (client_credentials grant)
+- Include a `/healthz` endpoint for liveness checks
+- Build as a Docker container for deployment
+
+---
+
+## Polling Strategy
+- Uses `GET https://api.twitch.tv/helix/streams` endpoint
+- Batches `user_id` and `game_id` requests in chunks of 100
+- Concurrent polling via goroutines and `sync.WaitGroup`
+- Rate-limiting with a semaphore (max ~13 requests/sec to respect 800 req/min limit)
+- Pagination support using `pagination.cursor`
+- Configurable polling interval via environment variable (e.g., every 30 seconds)
+
+---
+
+## Change Detection
+- Uses DragonflyDB (Redis-compatible) for stream tracking
+- For each poll, cache active streamers per `game_id` or `user_id`
+- Compare new list with previous set stored in DragonflyDB
+- Difference = streamers who just went live
+- New streamers trigger a message published to RabbitMQ
+
+---
+
+## RabbitMQ Publishing
+- Queue: `stream.online`
+- Message format: JSON conforming to internal schema
+```json
+{
+  "user_id": "123456",
+  "user_login": "streamername",
+  "game_id": "7890",
+  "title": "Going Live Now!",
+  "started_at": "2025-04-23T16:00:00Z"
+}
+```
+- RabbitMQ handles retries and dead-lettering
+
+---
+
+## Authentication
+- Uses Twitch App Access Token via `client_credentials` grant
+- Validates token before each batch request
+- Automatically renews token on expiration (401 response)
+
+---
+
+## Endpoints
+| Path       | Method | Purpose         |
+|------------|--------|-----------------|
+| `/healthz` | GET    | Liveness check  |
+
+---
+
+## Folder Structure
+```
+twitch-listener/
+├── cmd/
+│   └── twitch-listener/        # Main application entrypoint
+│       └── main.go
+├── internal/
+│   ├── poller/                 # Game and user poll logic
+│   │   ├── game.go
+│   │   └── user.go
+│   ├── twitch/                 # Twitch API client + auth
+│   │   ├── client.go
+│   │   └── auth.go
+│   ├── publisher/              # RabbitMQ publisher
+│   │   └── rabbitmq.go
+│   ├── storage/                # DragonflyDB (Redis) access
+│   │   └── dragonfly.go
+│   └── config/                 # Config loading and validation
+│       └── env.go
+├── Dockerfile
+├── go.mod
+├── go.sum
+└── README.md
+```
+
+---
+
+## Configuration (.env)
+```env
+POLL_INTERVAL_SECONDS=30
+TWITCH_CLIENT_ID=your_client_id
+TWITCH_CLIENT_SECRET=your_client_secret
+DRAGONFLY_URL=redis://localhost:6379
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+```
+
+---
+
+## Future Enhancements
+- Prometheus metrics integration
+- Optional Redis-based deduplication layer for rapid deployments
+- Dynamic target management via webhook-manager or user UI
+- Alerting for API failures or poll failures
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the project plan to reflect a new polling-based architecture for Twitch stream detection, with revised domain overviews and microservice responsibilities.
  - Added a detailed project plan document for the new stream polling service, outlining its design, configuration, and future enhancements.

- **Chores**
  - Introduced configuration and environment example files for the stream polling service to guide setup and deployment.
  - Added a `.gitignore` to exclude build artifacts and sensitive files from version control.
  - Established Go module dependencies for the new service.

- **New Features**
  - Implemented the initial version of a Twitch stream polling service, including configuration loading and Twitch API authentication with token management.
  - Added health check endpoint and logging setup for the new service.

- **Tests**
  - Introduced comprehensive unit tests for Twitch API token management, covering caching, expiration, error handling, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->